### PR TITLE
allow fastqc task to actually use available memory

### DIFF
--- a/modules/nf-core/modules/fastqc/main.nf
+++ b/modules/nf-core/modules/fastqc/main.nf
@@ -4,8 +4,8 @@ process FASTQC {
 
     conda (params.enable_conda ? "bioconda::fastqc=0.11.9" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
-        'quay.io/biocontainers/fastqc:0.11.9--0' }"
+        'https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0' :
+        'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads)
@@ -25,7 +25,7 @@ process FASTQC {
     if (meta.single_end) {
         """
         [ ! -f  ${prefix}.fastq.gz ] && ln -s $reads ${prefix}.fastq.gz
-        fastqc $args --threads $task.cpus ${prefix}.fastq.gz
+        fastqc $args --mem ${task.memory.toMega()} --threads $task.cpus ${prefix}.fastq.gz
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":


### PR DESCRIPTION
<!--
# nf-core/nanoseq pull request

Many thanks for contributing to nf-core/nanoseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/nanoseq/tree/master/.github/CONTRIBUTING.md)
-->

This allows the FASTQC process to actually make use of all the memory it's allotted. For short reads this is not typically necessary but for long reads it's essential. Also bumping up the version number of the fastqc containers in use because the process now uses the `--memory` flag of fastqc which was introduced in 0.12.0


## PR checklist

- [x] This comment contains a description of changes (with reason).
